### PR TITLE
[DO NOT MERGE] Version historique du template à n'utiliser que si la migration vers le template2 n'est pas possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,1 @@
-# ig-template
-
-Ce repository permet de fixer la charte graphique des Implementation Guides délivrés par l'ANS.
-Il ne permet pas d'être utilisé tel quel et sa modification doit être faite par des experts FHIR.
-
-Pour créer un IG, le plus simple est de forker [le repo ans-ig-sample](https://github.com/ansforge/FIG_ans-ig-sample) qui utilise ce template.
-
-# Acronymes
-FIG: FHIR Implementation Guide
-
-
-# About
-Cette page a été générée à partir de https://github.com/HL7/ig-template-base
+Version historique


### PR DESCRIPTION
Cette version du template est dépréciée et n'est plus maintenue par HL7.


Instruction de migration : https://github.com/ansforge/IG-documentation/wiki/Passage-au-template-2